### PR TITLE
Remove redundant pip deps from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM python:2.7-slim
 
 VOLUME ["/opt/dxleposervice-config"]
 
-# Install required packages
-RUN pip install "requests" "dxlbootstrap>=0.1.3" "dxlclient"
-
 # Copy application files
 COPY . /tmp/build
 WORKDIR /tmp/build
@@ -13,11 +10,8 @@ WORKDIR /tmp/build
 # Clean application
 RUN python ./clean.py
 
-# Build application
-RUN python ./setup.py bdist_wheel
-
-# Install application
-RUN pip install dist/*.whl
+# Install application and its dependencies
+RUN pip install .
 
 # Cleanup build
 RUN rm -rf /tmp/build


### PR DESCRIPTION
This commit removes the lines from the Dockerfile which install
service dependencies and build a separate wheel file. The
Dockerfile instead just pip installs the current project, which
installs the service and its dependencies defined in the
setup.py file.